### PR TITLE
04:00 JST(=19:00 UTC) に定期スケジュールを実行する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
   schedule:
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
-    # This example triggers the workflow every day at 23:00 UTC:
-    - cron:  '0 23 * * *'
+    # This example triggers the workflow every day at 19:00 UTC(JST+0900 04:00, Note: 19+9-24=4):
+    - cron:  '0 19 * * *'
 
 jobs:
   conv:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,11 @@
 ﻿name: bulid
 on:
- push:
- workflow_dispatch:
+  push:
+  workflow_dispatch:
+  schedule:
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
+    # This example triggers the workflow every day at 23:00 UTC:
+    - cron:  '0 23 * * *'
 
 jobs:
   conv:


### PR DESCRIPTION
04:00 JST(19:00 UTC) に定期スケジュールを実行する

* https://github.com/m-tmatma/build/actions/runs/3920639764/workflow の設定で 08:00JST に実行されるのを確認済み
* https://github.com/m-tmatma/build/actions/runs/3924905636/workflow の設定で 04:00JST に実行されるのを確認済み (時間精度まで確認)
* push, workflow_dispatch のところでインデントが空白 1文字になっているのでそこも修正しています。

