### PR TITLE
バグ修正 (retention-days の設定項目の誤り修正)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,10 +44,10 @@ jobs:
         with:
           name: artifacts_installer
           path: ./ttssh2/installer/Output/*.exe
-          RETENTION_DAYS: ${{env.RETENTION_DAYS}}
+          retention-days: ${{env.RETENTION_DAYS}}
       - name: artifacts_zip
         uses: actions/upload-artifact@v2
         with:
           name: artifacts_zip
           path: ./ttssh2/installer/Output/*.zip
-          RETENTION_DAYS: ${{env.RETENTION_DAYS}}
+          retention-days: ${{env.RETENTION_DAYS}}


### PR DESCRIPTION
バグ修正 (retention-days の設定項目の誤り修正)

リファクタリング時に誤って、 GitHub Actions 側の設定項目も一括置換していました。
https://github.com/actions/upload-artifact#retention-period
