### PR TITLE
SVN のリビジョンを取得

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,12 @@ jobs:
       - name: checkout
         shell: cmd
         run: svn checkout http://svn.osdn.net/svnroot/ttssh2/trunk "ttssh2" --quiet
+
+      - name: show svn rev
+        shell: cmd
+        working-directory: ttssh2
+        run: svn info --show-item revision
+
       - name: install
         shell: cmd
         run: |


### PR DESCRIPTION
SVN のリビジョンを取得

## 背景

* Actions の [Build 16](https://github.com/TeraTermProject/build/actions/runs/4027389547) では Artifacts が生成されていますが、
* Actions の [Build 17](https://github.com/TeraTermProject/build/actions/runs/4033171201) では Artifacts が生成されていません。

## 変更内容

SVN のどのリビジョンからデグレたか、わかるように SVN のリビジョンを表示します。
`show svn rev` の JOB の結果を表示すれば、どのリビジョンか確認できます。




