### PR TITLE
artifacts の中身が存在しないときにエラーにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
           name: artifacts_installer
           path: ./ttssh2/installer/Output/*.exe
           retention-days: ${{env.RETENTION_DAYS}}
+          if-no-files-found: error
 
       - name: artifacts_zip
         uses: actions/upload-artifact@v2
@@ -58,6 +59,7 @@ jobs:
           name: artifacts_zip
           path: ./ttssh2/installer/Output/*-snapshot.zip
           retention-days: ${{env.RETENTION_DAYS}}
+          if-no-files-found: error
 
       - name: artifacts_pdb_zip
         uses: actions/upload-artifact@v2
@@ -65,3 +67,4 @@ jobs:
           name: artifacts_pdb_zip
           path: ./ttssh2/installer/Output/*-snapshot_pdb.zip
           retention-days: ${{env.RETENTION_DAYS}}
+          if-no-files-found: error


### PR DESCRIPTION
artifacts の中身が存在しないときにエラーにする

## 背景

https://github.com/TeraTermProject/build/pull/4
にも書いた通り、現状ビルドに失敗して artifacts の生成ができない状態にある。

## 変更内容

artifacts の中身(インストーラなど) が存在しない場合にビルドを失敗させる。
本来はビルドに失敗したときに途中でビルドを中断するべきだが、ビルド処理自体は
SVN 側のリポジトリで管理されているため、ここでは最終成果物が空のてきに
ビルドを失敗させる。

一つでもビルド成果物があればビルドに成功しているように見えてしまう問題があります。

なお、SVN 側を修正しない状態でこの PR をマージすると Actions のビルドが失敗するようになります。
それがこの PR の目的ですが。




